### PR TITLE
Set permalink to control output file

### DIFF
--- a/jekyll-datapage_gen.gemspec
+++ b/jekyll-datapage_gen.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
 
   spec.name          = 'jekyll-datapage_gen'
-  spec.version       = '0.0.2'
+  spec.version       = '0.0.3'
   spec.authors       = ['Adolfo Villafiorita']
   spec.email         = ['adolfo.villafiorita@fbk.eu']
   spec.summary       = ''

--- a/lib/jekyll/datapage_gen.rb
+++ b/lib/jekyll/datapage_gen.rb
@@ -9,13 +9,15 @@ module Jekyll
     def initialize(site, base, dir, data, name, title, template)
       @site = site
       @base = base
-      @dir = File.join(dir, sanitize_filename(data[name]))
-      @name = 'index.html'
+      @dir = dir
+      name = sanitize_filename(data[name])
+      @name = name + '.html'
 
       self.process(@name)
       self.read_yaml(File.join(base, '_layouts'), template + ".html")
       self.data.merge!(data)
       self.data['title'] = data[title]
+      self.data['permalink'] = "/#{dir}/#{name}/"
     end
 
     private


### PR DESCRIPTION
This fixes a bug that was causing `index.html` to show up in the `page.url`.